### PR TITLE
Fixed a third value for boolean values

### DIFF
--- a/parrot_zik/model/base.py
+++ b/parrot_zik/model/base.py
@@ -44,6 +44,8 @@ class ParrotZikBase(object):
             return True
         elif result == "false":
             return False
+        elif result == "invalid_on":
+            return True
         else:
             raise AssertionError(result)
 


### PR DESCRIPTION
I activated the "Lou Reed" mode and the tray started raising this exception:

```
Traceback (most recent call last):
  File "build/bdist.linux-x86_64/egg/parrot_zik/utils.py", line 21, in run
  File "build/bdist.linux-x86_64/egg/parrot_zik/parrot_zik_tray.py", line 53, in reconnect
  File "build/bdist.linux-x86_64/egg/parrot_zik/interface/version1.py", line 28, in activate
  File "build/bdist.linux-x86_64/egg/parrot_zik/model/version1.py", line 34, in concert_hall
  File "build/bdist.linux-x86_64/egg/parrot_zik/model/base.py", line 48, in _result_to_bool
AssertionError: invalid_on
```

The `concert_hall` property was returning an `invalid_on` value and the dropdown menu was empty... I translated it into a `False`.
