### PR TITLE
Fixed cast when the value is an empty string

### DIFF
--- a/parrot_zik/model/base.py
+++ b/parrot_zik/model/base.py
@@ -16,7 +16,7 @@ class ParrotZikBase(object):
 
     def get_battery_level(self, field_name):
         answer = self.resource_manager.get("/api/system/battery")
-        return int(answer.system.battery[field_name])
+        return int(answer.system.battery[field_name] or 0)
 
     @property
     def friendly_name(self):


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "build/bdist.linux-x86_64/egg/parrot_zik/utils.py", line 21, in run
  File "build/bdist.linux-x86_64/egg/parrot_zik/parrot_zik_tray.py", line 40, in reconnect
  File "build/bdist.linux-x86_64/egg/parrot_zik/bluetooth_paired_devices.py", line 84, in connect
  File "build/bdist.linux-x86_64/egg/parrot_zik/bluetooth_paired_devices.py", line 22, in get_parrot_zik_mac_linux
ValueError: invalid literal for int() with base 10: ''
```
